### PR TITLE
Add option to compensate for overscan issues on some TVs

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -697,6 +697,7 @@ extern byte is_validate_mode;
 #endif // USE_REPLAY
 
 extern byte start_fullscreen INIT(= 0);
+extern byte overscan_amount INIT(= 0);
 extern word pop_window_width INIT(= 640);
 extern word pop_window_height INIT(= 400);
 extern byte use_custom_levelset INIT(= 0);

--- a/src/menu.c
+++ b/src/menu.c
@@ -1580,7 +1580,7 @@ void draw_settings_area(settings_area_type* settings_area) {
 
 void draw_settings_menu() {
 	settings_area_type* settings_area = get_settings_area(active_settings_subsection);
-	pause_menu_alpha = (settings_area == NULL) ? 220 : 255;
+	pause_menu_alpha = 140;
 	draw_rect_with_alpha(&screen_rect, color_0_black, pause_menu_alpha);
 
 	rect_type pause_rect_outer = {0, 10, 192, 80};

--- a/src/menu.c
+++ b/src/menu.c
@@ -331,9 +331,9 @@ int integer_scaling_possible =
 setting_type visuals_settings[] = {
 		#ifdef NXDK
 		{.id = SETTING_FULLSCREEN, .style = SETTING_STYLE_NUMBER, .number_type = SETTING_BYTE, .min = 75,
-		        .max = 100, .linked = &overscan_amount,
+				.max = 110, .linked = &overscan_amount,
 				.text = "Adjust overscan safe areas",
-				.explanation = "Adjust the amount of overscan safe areas."},
+				.explanation = "Adjust the size of the overscan safe areas."},
 		#else
 		{.id = SETTING_FULLSCREEN, .style = SETTING_STYLE_TOGGLE, .linked = &start_fullscreen,
 				.text = "Start fullscreen",
@@ -1292,9 +1292,11 @@ void set_setting_value(setting_type* setting, int value) {
 			default:
 			case SETTING_BYTE:
 				*(byte*) setting->linked = (byte) value;
+				#ifdef NXDK
 				if(setting->id == SETTING_FULLSCREEN){
 					apply_scale((float)value/100.0, (float)value/100.0);
 				}
+				#endif
 				break;
 			case SETTING_SBYTE:
 				*(sbyte*) setting->linked = (sbyte) value;

--- a/src/menu.c
+++ b/src/menu.c
@@ -330,8 +330,14 @@ int integer_scaling_possible =
 
 setting_type visuals_settings[] = {
 		{.id = SETTING_FULLSCREEN, .style = SETTING_STYLE_TOGGLE, .linked = &start_fullscreen,
+				#ifdef NXDK
+				.text = "Use overscan safe areas",
+				.explanation = "Start the game using overscan safe areas."},
+				#else
 				.text = "Start fullscreen",
 				.explanation = "Start the game in fullscreen mode.\nYou can also toggle fullscreen by pressing Alt+Enter."},
+				#endif
+		#ifndef NXDK
 		{.id = SETTING_USE_CORRECT_ASPECT_RATIO, .style = SETTING_STYLE_TOGGLE, .linked = &use_correct_aspect_ratio,
 				.text = "Use 4:3 aspect ratio",
 				.explanation = "Render the game in the originally intended 4:3 aspect ratio."
@@ -348,6 +354,7 @@ setting_type visuals_settings[] = {
 				.explanation = "Sharp - Use nearest neighbour resampling.\n"
 						"Fuzzy - First upscale to double size, then use smooth scaling.\n"
 						"Blurry - Use smooth scaling."},
+		#endif
 		{.id = SETTING_ENABLE_FADE, .style = SETTING_STYLE_TOGGLE, .linked = &enable_fade,
 				.text = "Fading enabled",
 				.explanation = "Turn fading on or off."},
@@ -1210,7 +1217,15 @@ void turn_setting_on_off(int setting_id, byte new_state, void* linked) {
 			break;
 		case SETTING_FULLSCREEN:
 			start_fullscreen = new_state;
+			#ifdef NXDK
+			if(start_fullscreen){
+				apply_scale(0.85, 0.85);
+			} else {
+				apply_scale(1.00, 1.00);
+			}
+			#else
 			SDL_SetWindowFullscreen(window_, (new_state != 0) * SDL_WINDOW_FULLSCREEN_DESKTOP);
+			#endif
 			break;
 		case SETTING_USE_CORRECT_ASPECT_RATIO:
 			use_correct_aspect_ratio = new_state;

--- a/src/menu.c
+++ b/src/menu.c
@@ -329,15 +329,15 @@ int integer_scaling_possible =
 ;
 
 setting_type visuals_settings[] = {
+		#ifdef NXDK
+		{.id = SETTING_FULLSCREEN, .style = SETTING_STYLE_NUMBER, .number_type = SETTING_BYTE, .min = 75,
+		        .max = 100, .linked = &overscan_amount,
+				.text = "Adjust overscan safe areas",
+				.explanation = "Adjust the amount of overscan safe areas."},
+		#else
 		{.id = SETTING_FULLSCREEN, .style = SETTING_STYLE_TOGGLE, .linked = &start_fullscreen,
-				#ifdef NXDK
-				.text = "Use overscan safe areas",
-				.explanation = "Start the game using overscan safe areas."},
-				#else
 				.text = "Start fullscreen",
 				.explanation = "Start the game in fullscreen mode.\nYou can also toggle fullscreen by pressing Alt+Enter."},
-				#endif
-		#ifndef NXDK
 		{.id = SETTING_USE_CORRECT_ASPECT_RATIO, .style = SETTING_STYLE_TOGGLE, .linked = &use_correct_aspect_ratio,
 				.text = "Use 4:3 aspect ratio",
 				.explanation = "Render the game in the originally intended 4:3 aspect ratio."
@@ -1217,15 +1217,7 @@ void turn_setting_on_off(int setting_id, byte new_state, void* linked) {
 			break;
 		case SETTING_FULLSCREEN:
 			start_fullscreen = new_state;
-			#ifdef NXDK
-			if(start_fullscreen){
-				apply_scale(0.85, 0.85);
-			} else {
-				apply_scale(1.00, 1.00);
-			}
-			#else
 			SDL_SetWindowFullscreen(window_, (new_state != 0) * SDL_WINDOW_FULLSCREEN_DESKTOP);
-			#endif
 			break;
 		case SETTING_USE_CORRECT_ASPECT_RATIO:
 			use_correct_aspect_ratio = new_state;
@@ -1300,6 +1292,9 @@ void set_setting_value(setting_type* setting, int value) {
 			default:
 			case SETTING_BYTE:
 				*(byte*) setting->linked = (byte) value;
+				if(setting->id == SETTING_FULLSCREEN){
+					apply_scale((float)value/100.0, (float)value/100.0);
+				}
 				break;
 			case SETTING_SBYTE:
 				*(sbyte*) setting->linked = (sbyte) value;
@@ -2012,6 +2007,7 @@ void process_ingame_settings_user_managed(SDL_RWops* rw, rw_process_func_type pr
 	process(joystick_only_horizontal);
 	process(enable_replay);
 	process(start_fullscreen);
+	process(overscan_amount);
 	process(use_correct_aspect_ratio);
 	process(use_integer_scaling);
 	process(scaling_type);

--- a/src/options.c
+++ b/src/options.c
@@ -180,6 +180,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("enable_text", &enable_text);
 		process_boolean("enable_info_screen", &enable_info_screen);
 		process_boolean("start_fullscreen", &start_fullscreen);
+		process_byte("overscan_amount", &overscan_amount, NULL);
 		process_word("pop_window_width", &pop_window_width, NULL);
 		process_word("pop_window_height", &pop_window_height, NULL);
 		process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
@@ -418,6 +419,7 @@ void set_options_to_default() {
 	enable_text = 1;
 	enable_info_screen = 1;
 	start_fullscreen = 0;
+	overscan_amount = 90;
 	use_correct_aspect_ratio = 1;
 	use_integer_scaling = 0;
 	scaling_type = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -418,7 +418,7 @@ void set_options_to_default() {
 	enable_text = 1;
 	enable_info_screen = 1;
 	start_fullscreen = 0;
-	use_correct_aspect_ratio = 0;
+	use_correct_aspect_ratio = 1;
 	use_integer_scaling = 0;
 	scaling_type = 0;
 	enable_controller_rumble = 1;

--- a/src/proto.h
+++ b/src/proto.h
@@ -576,6 +576,7 @@ void __pascal far play_sound_from_buffer(sound_buffer_type far *buffer);
 void turn_music_on_off(byte new_state);
 void __pascal far turn_sound_on_off(byte new_state);
 int __pascal far check_sound_playing();
+void apply_scale(float scaleX, float scaleY);
 void apply_aspect_ratio();
 void window_resized();
 void __pascal far set_gr_mode(byte grmode);

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -2237,7 +2237,7 @@ void __pascal far show_quotes() {
 }
 
 const rect_type splash_text_1_rect = {0, 0, 50, 320};
-const rect_type splash_text_2_rect = {50, 0, 200, 320};
+const rect_type splash_text_2_rect = {40, 0, 200, 320};
 
 #ifndef NXDK
 const char* splash_text_1 = "SDLPoP " SDLPOP_VERSION;
@@ -2260,8 +2260,6 @@ const char* splash_text_2 =
 #else
 const char* splash_text_1 = "SDLPoPX " SDLPOP_VERSION;
 const char* splash_text_2 =
-		"OG Xbox port by Ryzee119\n"
-		"\n"
 		"See github.com/Ryzee119/SDLPoPX\n"
 		"Ported with github.com/XboxDev/nxdk\n"
 		"Forked from github.com/NagyD/SDLPoP\n"
@@ -2272,7 +2270,7 @@ const char* splash_text_2 =
 		"START  - Pause Game\n"
 		"WHITE - Start/Stop Recording\n"
 		"BLACK - Cycle Existing Replays\n"
-		"\n\n"
+		"\n"
 		"Press any key to continue...";
 #endif
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2476,14 +2476,9 @@ void __pascal far set_gr_mode(byte grmode) {
 	}
 	init_overlay();
 	init_scaling();
+	apply_scale((float)overscan_amount/100.0, (float)overscan_amount/100.0);
 	if (start_fullscreen) {
 		SDL_ShowCursor(SDL_DISABLE);
-		//Microsoft's Xbox game developer guidelines recommend using 85 percent of the screen
-		//width and height, or a title safe area of 7.5% per side.
-		//Ref https://en.wikipedia.org/wiki/Overscan
-		apply_scale(0.85, 0.85);
-	} else {
-		apply_scale(1.00, 1.00);
 	}
 
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2304,6 +2304,19 @@ int __pascal far check_sound_playing() {
 	return speaker_playing || digi_playing || midi_playing || ogg_playing;
 }
 
+void apply_scale(float scaleX, float scaleY){
+	int render_width, render_height;
+	SDL_Rect vp;
+
+	SDL_RenderGetLogicalSize(renderer_, &render_width, &render_height);
+	vp.w=render_width * scaleX;
+	vp.h=render_height * scaleX;
+	vp.x=(render_width - vp.w) / 2;
+	vp.y=(render_height - vp.h) / 2;
+
+	SDL_RenderSetViewport(renderer_, &vp);
+}
+
 void apply_aspect_ratio() {
 	// Allow us to use a consistent set of screen co-ordinates, even if the screen size changes
 	if (use_correct_aspect_ratio) {
@@ -2465,6 +2478,12 @@ void __pascal far set_gr_mode(byte grmode) {
 	init_scaling();
 	if (start_fullscreen) {
 		SDL_ShowCursor(SDL_DISABLE);
+		//Microsoft's Xbox game developer guidelines recommend using 85 percent of the screen
+		//width and height, or a title safe area of 7.5% per side.
+		//Ref https://en.wikipedia.org/wiki/Overscan
+		apply_scale(0.85, 0.85);
+	} else {
+		apply_scale(1.00, 1.00);
 	}
 
 


### PR DESCRIPTION
Adjustable from 75% to 110% from the in game settings menu

Default value is 90%.  If user adjusts the value, it is saved to the UDATA saves folder as per other game settings

![overscan_90](https://user-images.githubusercontent.com/21236406/82417524-d36dbb80-9aba-11ea-8c0a-46c7d5475adb.png)

![overscan_90_1](https://user-images.githubusercontent.com/21236406/82417527-d5377f00-9aba-11ea-8b19-9651035d1cfe.png)
